### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "mailparser": "^3.7.4",
     "pushover-notifications": "^1.2.3",
-    "smtp-server": "^3.13.6",
-    "escape-string-regexp": "^5.0.0"
+    "smtp-server": "^3.13.6"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/super-linter-output/super-linter-summary.md
+++ b/super-linter-output/super-linter-summary.md
@@ -2,5 +2,6 @@
 
 | Language | Validation result |
 | -------- | ----------------- |
+| JSON     | Pass ✅           |
 
 All files and directories linted successfully


### PR DESCRIPTION
feat!: replace IGNORE_SUBJECT_REGEX with IGNORE_SUBJECT_LITERAL

BREAKING CHANGE: regex-based filtering is no longer supported.  
Subjects are now filtered using case-insensitive literal substring matching.  
Multiple values can be provided as a comma-separated list in `IGNORE_SUBJECT_LITERAL`.  
The dependency `escape-string-regexp` has been removed.